### PR TITLE
Create configure.py

### DIFF
--- a/quantecon_book_networks/__init__.py
+++ b/quantecon_book_networks/__init__.py
@@ -7,3 +7,4 @@ Website: https://github.com/quantecon/book-networks
 
 __version__ = '0.3'
 
+from .configure import config

--- a/quantecon_book_networks/configure.py
+++ b/quantecon_book_networks/configure.py
@@ -1,0 +1,10 @@
+import matplotlib
+from matplotlib import rc
+
+def config(target="matplotlib"):
+    if target == "matplotlib":
+        rc('text', usetex=True)
+        matplotlib.rcParams['mathtext.fontset'] = 'custom'
+        matplotlib.rcParams['mathtext.rm'] = 'Bitstream Vera Sans'
+        matplotlib.rcParams['mathtext.it'] = 'Bitstream Vera Sans:italic'
+        matplotlib.rcParams['mathtext.bf'] = 'Bitstream Vera Sans:bold'   


### PR DESCRIPTION
Thanks @mmcky . As we discussed in [issue 36](https://github.com/QuantEcon/book-networks/issues/36) this PR updates the ``configure.py``, which configures matplotlib setups for figures in the [networks textbook webpage](https://github.com/QuantEcon/book-networks).

Looking forward to your comments.