### PR TITLE
MAINT: add quantecon as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     'pandas',
     'matplotlib',
     'pandas-datareader',
-    'networkx'
+    'networkx',
+    'quantecon'
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR adds `quantecon` package as a dependency to ensure it is installed into environments. 