### PR TITLE
Add `wbgapi` as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     'matplotlib',
     'pandas-datareader',
     'networkx',
+    'wbgapi',
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR fixes the following issue:
```bash
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[5], line 9
      7 import matplotlib.cm as cm
      8 import quantecon_book_networks.input_output as qbn_io
----> 9 import quantecon_book_networks.data as qbn_data
     11 import matplotlib.patches as mpatches

File /lib/python3.11/site-packages/quantecon_book_networks/data.py:8
      6 import json
      7 from pandas_datareader import wb
----> 8 import wbgapi as wbg
     10 ## Utilities
     11 def read_Z(data_file='data/csv_files/adjacency_matrix.csv', t=10):

ModuleNotFoundError: No module named 'wbgapi'
```

Fixes #18 

cc @mmcky 